### PR TITLE
Introduce riscv64 architecture build and publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm]
+        os: [ubuntu-latest, ubuntu-24.04-arm, ubuntu-24.04-riscv]
     outputs:
       tag: ${{ steps.read_ver.outputs.tag }}
       file_ver: ${{ steps.read_ver.outputs.file_ver }}
@@ -61,6 +61,7 @@ jobs:
           CIBW_BUILD: "cp39-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
+          CIBW_MANYLINUX_RISCV64_IMAGE: manylinux_2_39
           CIBW_ARCHS: auto64
           CIBW_TEST_REQUIRES: pytest syrupy
           CIBW_TEST_COMMAND: python -m pytest -vv {project}/tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install build tools
-        run: pip install setuptools build cibuildwheel==2.23.2
+        run: pip install setuptools build cibuildwheel==3.4.1
 
       - name: Read version from setup.py & verify tag
         id: read_ver
@@ -56,7 +56,7 @@ jobs:
           print(f"✅ Version OK: tag={tag} matches setup.py={ver}")
 
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir dist
+        run: python -m cibuildwheel --enable pypy --output-dir dist
         env:
           CIBW_BUILD: "cp39-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm]
+        os: [ubuntu-latest, ubuntu-24.04-arm, ubuntu-24.04-riscv]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm]
+        os: [ubuntu-latest, ubuntu-24.04-arm, ubuntu-24.04-riscv]
 
     steps:
       - uses: actions/checkout@v4
@@ -28,6 +28,7 @@ jobs:
           CIBW_BUILD: "cp39-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
+          CIBW_MANYLINUX_RISCV64_IMAGE: manylinux_2_39
           CIBW_ARCHS: auto64
           CIBW_TEST_REQUIRES: pytest syrupy
           CIBW_TEST_COMMAND: python -m pytest -vv {project}/tests

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -20,10 +20,10 @@ jobs:
           python-version: "3.12"
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.23.2
+        run: python -m pip install cibuildwheel==3.4.1
 
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
+        run: python -m cibuildwheel --enable pypy --output-dir wheelhouse
         env:
           CIBW_BUILD: "cp39-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28


### PR DESCRIPTION
Depends on rhasspy/pyspeex-noise#4 and configure the repository GitHub org or account with the add-on for access to free community RISC-V runner https://riseproject-dev.github.io/riscv-runner/